### PR TITLE
Adjust base styles for mobile-first, use media query for screens wider than 1024px

### DIFF
--- a/DerpyWebApp/Website/slideshow/slide1.htm
+++ b/DerpyWebApp/Website/slideshow/slide1.htm
@@ -7,8 +7,10 @@
       <header>
         <button onclick="window.location.href='slide2.htm';">Next       
       </header>
-      <div class="titleName">
-        <center>Baby's First Serverless<br>Jeremy Brown</center>
-      </div>
+      <main>
+        <div class="titleName">
+          Baby's First Serverless<br>Jeremy Brown
+        </div>
+      </main>
     </body>
   </html>

--- a/DerpyWebApp/Website/slideshow/slide2.htm
+++ b/DerpyWebApp/Website/slideshow/slide2.htm
@@ -8,18 +8,16 @@
         <button onclick="window.location.href = 'slide1.htm';">Back
         <button onclick="window.location.href = 'slide3.htm';">Next
       </header>
-      <div class="titleBar">
-        <p>
-          Get-Presenter
-        </p>
-      </div>
-      <div class="bulletsDiv">
-        <ul>
-            <li>Name: Jeremy Brown</li>
-            <li>Email: Jeremy.Isaac.Brown@gmail.com</li>
-            <li>Twitter: Banana_Jama</li>
-            <li>Github: BananaJama</li>
-        </ul>
+      <main>
+        <div class="titleBar">Get-Presenter</div>
+        <div class="bulletsDiv">
+          <ul>
+              <li>Name: Jeremy Brown</li>
+              <li>Email: Jeremy.Isaac.Brown@gmail.com</li>
+              <li>Twitter: Banana_Jama</li>
+              <li>Github: BananaJama</li>
+          </ul>
+      </main>
       </div>
     </body>
  </html>

--- a/DerpyWebApp/Website/slideshow/slide3.htm
+++ b/DerpyWebApp/Website/slideshow/slide3.htm
@@ -8,18 +8,18 @@
         <button onclick="window.location.href = 'slide2.htm';">Back
         <button onclick="window.location.href = 'slide4.htm';">Next
       </header>
-      <div class="titleBar">
-        <p>
-          Get-Synopsis
-        </p>
-      </div>
-      <div class="bulletsDiv">
-        <ul>
-            <li>What is an Azure Static Website</li>
-            <li>How do we interact with a REST API</li>
-            <li>What is an Azure Function</li>
-            <li>Profit??</li>
-        </ul>
-      </div>
+      <main>
+        <div class="titleBar">
+            Get-Synopsis
+        </div>
+        <div class="bulletsDiv">
+          <ul>
+              <li>What is an Azure Static Website</li>
+              <li>How do we interact with a REST API</li>
+              <li>What is an Azure Function</li>
+              <li>Profit??</li>
+          </ul>
+        </div>
+      </main>
     </body>
  </html>

--- a/DerpyWebApp/Website/slideshow/slide4.htm
+++ b/DerpyWebApp/Website/slideshow/slide4.htm
@@ -8,17 +8,17 @@
         <button onclick="window.location.href = 'slide3.htm';">Back
         <button onclick="window.location.href = 'slide5.htm';">Next
       </header>
-      <div class="titleBar">
-        <p>
-          Get-Definition -Name "Static Website"
-        </p>
-      </div>
-      <div class="bulletsDiv">
-        <ul>
-            <li>Serves static content from a storage container</li>
-            <li>Serves out of a hard coded blob container ($web)</li>
-            <li>Provides the foundation for server-less architectures</li>
-        </ul>
-      </div>
+      <main>
+        <div class="titleBar">
+            Get-Definition -Name "Static Website"
+        </div>
+        <div class="bulletsDiv">
+          <ul>
+              <li>Serves static content from a storage container</li>
+              <li>Serves out of a hard coded blob container ($web)</li>
+              <li>Provides the foundation for server-less architectures</li>
+          </ul>
+        </div>
+      </main>
     </body>
  </html>

--- a/DerpyWebApp/Website/slideshow/slide5.htm
+++ b/DerpyWebApp/Website/slideshow/slide5.htm
@@ -8,18 +8,18 @@
         <button onclick="window.location.href = 'slide4.htm';">Back
         <button onclick="window.location.href = 'slide6.htm';">Next
       </header>
-      <div class="titleBar">
-        <p>
-          Get-Definition -Name "REST APIs"
-        </p>
-      </div>
-      <div class="bulletsDiv">
-        <ul>
-          <li><strong>RE</strong>presentational <strong>S</strong>tate <strong>T</strong>ransfer</li>
-          <li>Uses resources methods like GET/POST/PUT/DELETE</li>
-          <li>Passes requests between client and server as a URI</li>
-          <li>We'll use Invoke-RestMethod</li>
-        </ul>
-      </div>
+      <main>
+        <div class="titleBar">
+            Get-Definition -Name "REST APIs"
+        </div>
+        <div class="bulletsDiv">
+          <ul>
+            <li><strong>RE</strong>presentational <strong>S</strong>tate <strong>T</strong>ransfer</li>
+            <li>Uses resources methods like GET/POST/PUT/DELETE</li>
+            <li>Passes requests between client and server as a URI</li>
+            <li>We'll use Invoke-RestMethod</li>
+          </ul>
+        </div>
+      </main>
     </body>
  </html>

--- a/DerpyWebApp/Website/slideshow/slide6.htm
+++ b/DerpyWebApp/Website/slideshow/slide6.htm
@@ -8,18 +8,18 @@
         <button onclick="window.location.href = 'slide5.htm';">Back
         <button onclick="window.location.href = 'slide7.htm';">Next
       </header>
-      <div class="titleBar">
-        <p>
-          Get-Definition -Name "AzFunction"
-        </p>
-      </div>
-      <div class="bulletsDiv">
-        <ul>
-          <li>Small pieces of code</li>
-          <li>Triggered by a specific event</li>
-          <li>Constructed the same way you would locally</li>
-          <li>Outputs to many options</li>
-        </ul>
-      </div>
+      <main>
+        <div class="titleBar">
+            Get-Definition -Name "AzFunction"
+        </div>
+        <div class="bulletsDiv">
+          <ul>
+            <li>Small pieces of code</li>
+            <li>Triggered by a specific event</li>
+            <li>Constructed the same way you would locally</li>
+            <li>Outputs to many options</li>
+          </ul>
+        </div>
+      </main>
     </body>
  </html>

--- a/DerpyWebApp/Website/slideshow/slide7.htm
+++ b/DerpyWebApp/Website/slideshow/slide7.htm
@@ -8,10 +8,10 @@
         <button onclick="window.location.href = 'slide6.htm';">Back
         <button onclick="window.location.href = 'slide8.htm';">Next
       </header>
-      <div class="titleBar">
-        <p>
-          Get-BigReveal
-        </p>
-      </div>
+      <main>
+        <div class="titleBar">
+            Get-BigReveal
+        </div>
+      </main>
     </body>
  </html>

--- a/DerpyWebApp/Website/slideshow/slide8.htm
+++ b/DerpyWebApp/Website/slideshow/slide8.htm
@@ -8,6 +8,8 @@
         <button onclick="window.location.href = 'slide7.htm';">Back
         <button onclick="window.location.href = 'slide1.htm';">Start
       </header>
-      <img src="hamster.gif" class="hamster">
+      <main>
+        <img src="hamster.gif" class="hamster">
+      </main>
     </body>
  </html>

--- a/DerpyWebApp/Website/slideshow/styles.css
+++ b/DerpyWebApp/Website/slideshow/styles.css
@@ -1,34 +1,80 @@
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+ul, li { 
+  margin: 0;
+  padding: 0;
+}
+
+p {
+  margin: 0;
+}
+
 body {
-    background-size: 100% 100%;
-    background-image: url('BabyBackground.jpg');
-    background-repeat: no-repeat;
+  background-size: cover;
+  background-position: left bottom;
+  background-image: url('BabyBackground.jpg');
+  background-repeat: no-repeat;
+}
+
+header {
+  position: fixed
+}
+
+main {
+  height: 100%;
+  margin-left: 22rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.titleName {
+  font-size: 48pt;
+  text-align: center;
+  margin-left: -6rem;
+}
+
+.titleBar {
+  width: 100%;
+  font-size: 30pt;
+  color: navy; 
+  margin-bottom: 1rem;
+  margin-left: -6rem;
+}
+
+.bulletsDiv {
+  width: 100%;
+  font-size: 24pt;
+}
+
+.hamster {
+  height: 400px;
+  margin-left: -5rem;
+}
+
+@media screen and (min-width: 1024px) {
+  .titleName {
+    font-size: 72pt;
+  }
+
+  main {
+    margin-left: 36rem;
   }
 
   .titleBar {
-    position: absolute;
-    top: 0px;
-    left: 90px; 
-    font-size: 75pt;
-    color: navy; 
+    font-size: 42pt;
   }
 
-  .titleName {
-    position: absolute;
-    top: 350px;
-    left:550px; 
-    font-size: 65pt;
-  }
-  
   .bulletsDiv {
-    position: absolute;
-    top: 250px;
-    left: 550px;
-    font-size: 45pt;
+    font-size: 32pt;
   }
 
   .hamster {
-    position: absolute;
-    top: 200px;
-    left: 600px;
     height: 600px;
   }
+}


### PR DESCRIPTION
Hey man,

🎨 This PR adjusts base styles to assume mobile-first and applies a media-query to make adjustments for screens wider than `1024px`. 

First, we apply some reset styles:

```
html, body {
  height: 100%;
  margin: 0;
  padding: 0;
}

ul, li { 
  margin: 0;
  padding: 0;
}

p {
  margin: 0;
}
```

This just makes things predictable and easier to work with. You have to set `height` on `html,body` to `100%` of screen height because by default, they will be as high as the content (which is why the baby was straight-up SMASHED). 

For baby, we give `body` a `background-size` of `cover` (which tells baby to stretch-to-cover without screwing with aspect ratio) and then say "anchor it to the bottom left" (i.e. `background-position: left bottom;`) to make sure baby is visible on all slides.

Next, we stick the `<header/>` that has our pagination controls to the top of the screen, which takes it out of the document flow (makes positioning things easier).

Next, we create a `<main/>` element to wrap all page contents outside the header. This might as well have been a `<div/>`, but we just needed something to set [`display: flex`](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) on. From there, we tell it to orient the main axis on the column (so it stacks children). Then, we tell it to align all content vertically and horizontally and set `main` height to fill the vertical space. Ultimate effect: content is horizontally and vertically centered. Lastly, we set an arbitrary `margin-left` to move all that out of baby's way (`22rem` was what looked alright on an iPhone 7/X using Firefox dev tools).

There are some other font-size adjustments that are arbitrary to "look good". Important to note that the base styles are adjusted **for mobile**.

To deal with large screens, we use a [`@media` query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries). It basically says "if screens are wider than 1024px, then apply these CSS rules on top of what's already applied". So, we mess around with `<main/>`'s `margin-left` again (move it further right because baby is bigger). We adjust font-sizes because people have old eyes. And lastly, we make hamster super large.

Check this branch out and make sure it looks right on whatever you're presenting from. That's all that matters. Everyone else can get bent. 😁 

If you have any questions, lemme know man. Hope this helps and gives you some crumbs to continue the knowledgeeeeee.