### PR TITLE
Use CSS grid to create template areas that we lock different content into

### DIFF
--- a/DerpyWebApp/Website/slideshow/slide7.htm
+++ b/DerpyWebApp/Website/slideshow/slide7.htm
@@ -6,7 +6,6 @@
     <body>
       <header>
         <button onclick="window.location.href = 'slide6.htm';">Back
-        <button onclick="window.location.href = 'slide8.htm';">Next
       </header>
       <main>
         <div class="titleBar">

--- a/DerpyWebApp/Website/slideshow/styles.css
+++ b/DerpyWebApp/Website/slideshow/styles.css
@@ -1,3 +1,7 @@
+html {
+  font-size: 100%;
+}
+
 html, body {
   height: 100%;
   margin: 0;
@@ -25,59 +29,47 @@ header {
 }
 
 main {
+  /* background: rgba(0,0,255,0.5); */
   height: 100%;
-  margin-left: 5rem;
-  display: flex;
-  flex-direction: column;
-  align-items: left;
-  justify-content: center;
+  display: grid;
+  grid-template-areas: "h h h"
+                        ". c c";
+  grid-template-rows: 1fr 2fr;
+  grid-template-columns: 1.25fr 2fr;
 }
 
 .titleName {
-  font-size: 48pt;
+  font-size: calc(1.3rem + 3.6vw);
+  grid-area: h;
   text-align: center;
-  margin-left: -6rem;
+  margin-top: calc(50vh - 8rem);
+  margin-left: 12rem;
 }
 
 .titleBar {
+  /* background: rgba(0,255,0,0.5); */
+  padding: 2rem 0 0 2rem;
   width: 100%;
   font-size: 30pt;
+  grid-area: h;
   color: navy; 
-  margin-top: -8rem;
-  margin-bottom: 7rem;
-  margin-left: 0rem;
 }
 
 .bulletsDiv {
-  width: 100%;
-  font-size: 24pt;
-  margin-left: 15rem;
+  /* background: rgba(255,0,0,0.5); */
+  grid-area: c;
+  font-size: calc(1rem + 2vw);
+  padding-right: 2rem;
 }
 
 .hamster {
-  height: 300px;
-  width: 300px;
-  margin-left: 20rem;
+  grid-area: c;
+  display: block;
+  height: 100%;
 }
 
 @media screen and (min-width: 1024px) {
-  .titleName {
-    font-size: 72pt;
-  }
-
-  main {
-    margin-left: 36rem;
-  }
-
   .titleBar {
     font-size: 42pt;
-  }
-
-  .bulletsDiv {
-    font-size: 32pt;
-  }
-
-  .hamster {
-    height: 600px;
   }
 }


### PR DESCRIPTION
So, I took some more stabby stab at this and it needs a little more tweaking. I can spend some more time on it around lunch tomorrow.

![image](https://user-images.githubusercontent.com/2453394/74802105-d8965100-52a6-11ea-854c-2048fbac1627.png)

I left commented-out background colors on the different grid areas so you can see how it kinda works. But the gist is you set a container to `display: grid;` and specify `grid-template-areas` roughly approximating your  columns and rows. Then you set `grid-template-rows` and `grid-template-columns` to lock in widths/heights for each row.

I think the last thing that needs to be done here is get the slide titles nestled over with the bullets again and then play with font-sizes on mobile/widescreen.